### PR TITLE
Перенес MdoReference из MDClasses

### DIFF
--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -1,0 +1,3 @@
+# Default ignored files
+/shelf/
+/workspace.xml

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -24,6 +24,7 @@ version = gitVersionCalculator.calculateVersion("v")
 dependencies {
 
     implementation("org.apache.commons", "commons-collections4", "4.4")
+    implementation("com.github.1c-syntax", "utils", "0.4.0")
 
     // логирование
     implementation("org.slf4j", "slf4j-api", "1.7.30")

--- a/src/main/java/com/github/_1c_syntax/bsl/types/MdoReference.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/types/MdoReference.java
@@ -94,8 +94,8 @@ public class MdoReference {
    * @return Ссылка на объект
    */
   public static MdoReference create(@NonNull MDOType mdoType, @NonNull String name) {
-    var mdoRef = mdoType.getName() + "." + name;
-    var mdoRefRu = mdoType.getNameRu() + "." + name;
+    var mdoRef = (mdoType.getName() + "." + name).intern();
+    var mdoRefRu = (mdoType.getNameRu() + "." + name).intern();
 
     return getOrCompute(mdoType, mdoRef, mdoRefRu);
   }
@@ -111,8 +111,8 @@ public class MdoReference {
   public static MdoReference create(@NonNull MdoReference mdoReferenceOwner,
                                     @NonNull MDOType mdoType,
                                     @NonNull String name) {
-    var mdoRef = mdoReferenceOwner.getMdoRef() + "." + mdoType.getName() + "." + name;
-    var mdoRefRu = mdoReferenceOwner.getMdoRefRu() + "." + mdoType.getNameRu() + "." + name;
+    var mdoRef = (mdoReferenceOwner.getMdoRef() + "." + mdoType.getName() + "." + name).intern();
+    var mdoRefRu = (mdoReferenceOwner.getMdoRefRu() + "." + mdoType.getNameRu() + "." + name).intern();
 
     return getOrCompute(mdoType, mdoRef, mdoRefRu);
   }

--- a/src/main/java/com/github/_1c_syntax/bsl/types/MdoReference.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/types/MdoReference.java
@@ -1,0 +1,184 @@
+/*
+ * This file is a part of BSL Common library.
+ *
+ * Copyright (c) 2021 - 2022
+ * Tymko Oleg <olegtymko@yandex.ru>, Maximov Valery <maximovvalery@gmail.com> and contributors
+ *
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ *
+ * BSL Common library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3.0 of the License, or (at your option) any later version.
+ *
+ * BSL Common library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with BSL Common library.
+ */
+package com.github._1c_syntax.bsl.types;
+
+import lombok.EqualsAndHashCode;
+import lombok.NonNull;
+import lombok.ToString;
+import lombok.Value;
+import org.apache.commons.collections4.map.CaseInsensitiveMap;
+
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.locks.ReentrantLock;
+import java.util.regex.Pattern;
+
+/**
+ * Ссылка на объект в формате ВидОбъектаМетаданных.ИмяОбъекта
+ */
+@Value
+@EqualsAndHashCode(of = {"mdoRef"})
+@ToString(of = {"mdoRef"})
+public class MdoReference {
+  /**
+   * Ссылка на пустую ссылку
+   */
+  public static final MdoReference EMPTY = new MdoReference(MDOType.UNKNOWN, "", "");
+
+  private static final String REF_SPLIT_REGEX = "\\.";
+  private static final Pattern REF_SPLIT_PATTERN = Pattern.compile(REF_SPLIT_REGEX);
+
+  /**
+   * Кэш всех ссылок
+   */
+  private static final Map<String, MdoReference> REFERENCES = new CaseInsensitiveMap<>();
+
+  private static final ReentrantLock referenceLock = new ReentrantLock();
+
+  /**
+   * Тип объекта метаданных
+   */
+  MDOType type;
+
+  /**
+   * Строковое представление ссылки
+   */
+  String mdoRef;
+
+  /**
+   * Строковое представление ссылки на русском языке
+   */
+  String mdoRefRu;
+
+  private MdoReference(MDOType type, String mdoRef, String mdoRefRu) {
+    this.type = type;
+    this.mdoRef = mdoRef;
+    this.mdoRefRu = mdoRefRu;
+  }
+
+  /**
+   * Создает ссылку, сохраняя ее в кэш.
+   * Ответственность за корректность сформированных представлений ссылки ложится на вызывающую сторону
+   *
+   * @param mdoType  Тип метаданных
+   * @param mdoRef   Строковая ссылка
+   * @param mdoRefRu Строковая ссылка на русском языке
+   * @return Ссылка на объект
+   */
+  public static MdoReference create(@NonNull MDOType mdoType, @NonNull String mdoRef, @NonNull String mdoRefRu) {
+    return getOrCompute(mdoType, mdoRef, mdoRefRu);
+  }
+
+  /**
+   * Создает ссылку, сохраняя ее в кэш
+   *
+   * @param mdoType Тип метаданных
+   * @param name    Имя объекта метаданных
+   * @return Ссылка на объект
+   */
+  public static MdoReference create(@NonNull MDOType mdoType, @NonNull String name) {
+    var mdoRef = mdoType.getName() + "." + name;
+    var mdoRefRu = mdoType.getNameRu() + "." + name;
+
+    return getOrCompute(mdoType, mdoRef, mdoRefRu);
+  }
+
+  /**
+   * Создание дочерней ссылки
+   *
+   * @param mdoReferenceOwner Ссылка родитель
+   * @param mdoType           Тип дочерней ссылки
+   * @param name              Имя дочернего элемента
+   * @return Ссылка на элемент
+   */
+  public static MdoReference create(@NonNull MdoReference mdoReferenceOwner,
+                                    @NonNull MDOType mdoType,
+                                    @NonNull String name) {
+    var mdoRef = mdoReferenceOwner.getMdoRef() + "." + mdoType.getName() + "." + name;
+    var mdoRefRu = mdoReferenceOwner.getMdoRefRu() + "." + mdoType.getNameRu() + "." + name;
+
+    return getOrCompute(mdoType, mdoRef, mdoRefRu);
+  }
+
+  /**
+   * Создает ссылку, сохраняя ее в кэш
+   *
+   * @param fullName Строковая ссылка на объект метаданных
+   * @return Ссылка на объект
+   */
+  public static MdoReference create(@NonNull String fullName) {
+    var nameParts = REF_SPLIT_PATTERN.split(fullName);
+    if (nameParts.length <= 1) {
+      throw new IllegalArgumentException("Incorrect full name " + fullName);
+    }
+
+    MdoReference ref = null;
+    var step = 2;
+    for (var i = 0; i < nameParts.length; i += step) {
+      var mdoType = MDOType.fromValue(nameParts[i]);
+      if (mdoType.isEmpty()) {
+        continue;
+      }
+      var mdoName = nameParts[i + 1];
+      if (ref == null) {
+        ref = create(mdoType.get(), mdoName);
+      } else {
+        ref = create(ref, mdoType.get(), mdoName);
+      }
+    }
+
+    if (ref == null) {
+      throw new IllegalArgumentException("Incorrect full name " + fullName);
+    }
+
+    return ref;
+  }
+
+  /**
+   * Выполняет поиск ссылки по имени, используя кэш прочитанных ранее
+   *
+   * @param mdoRef Строковое представление ссылки
+   * @return Optional-контейнер для ссылки
+   */
+  public static Optional<MdoReference> find(@NonNull String mdoRef) {
+    Optional<MdoReference> result = Optional.empty();
+    referenceLock.lock();
+    if (REFERENCES.containsKey(mdoRef)) {
+      result = Optional.of(REFERENCES.get(mdoRef));
+    }
+    referenceLock.unlock();
+    return result;
+  }
+
+  private static MdoReference getOrCompute(@NonNull MDOType mdoType, @NonNull String mdoRef, @NonNull String mdoRefRu) {
+    referenceLock.lock();
+    if (REFERENCES.containsKey(mdoRef)) {
+      referenceLock.unlock();
+      return REFERENCES.get(mdoRef);
+    }
+    var newMdoReference = new MdoReference(mdoType, mdoRef, mdoRefRu);
+    REFERENCES.put(newMdoReference.getMdoRef(), newMdoReference);
+    REFERENCES.put(newMdoReference.getMdoRefRu(), newMdoReference);
+    referenceLock.unlock();
+    return newMdoReference;
+  }
+}

--- a/src/main/java/com/github/_1c_syntax/bsl/types/MdoReference.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/types/MdoReference.java
@@ -21,6 +21,7 @@
  */
 package com.github._1c_syntax.bsl.types;
 
+import com.github._1c_syntax.utils.StringInterner;
 import lombok.EqualsAndHashCode;
 import lombok.NonNull;
 import lombok.ToString;
@@ -45,6 +46,8 @@ public class MdoReference {
 
   private static final String REF_SPLIT_REGEX = "\\.";
   private static final Pattern REF_SPLIT_PATTERN = Pattern.compile(REF_SPLIT_REGEX);
+
+  private static final StringInterner stringInterner = new StringInterner();
 
   /**
    * Кэш всех ссылок
@@ -94,8 +97,8 @@ public class MdoReference {
    * @return Ссылка на объект
    */
   public static MdoReference create(@NonNull MDOType mdoType, @NonNull String name) {
-    var mdoRef = (mdoType.getName() + "." + name).intern();
-    var mdoRefRu = (mdoType.getNameRu() + "." + name).intern();
+    var mdoRef = stringInterner.intern(mdoType.getName() + "." + name);
+    var mdoRefRu = stringInterner.intern(mdoType.getNameRu() + "." + name);
 
     return getOrCompute(mdoType, mdoRef, mdoRefRu);
   }
@@ -111,8 +114,8 @@ public class MdoReference {
   public static MdoReference create(@NonNull MdoReference mdoReferenceOwner,
                                     @NonNull MDOType mdoType,
                                     @NonNull String name) {
-    var mdoRef = (mdoReferenceOwner.getMdoRef() + "." + mdoType.getName() + "." + name).intern();
-    var mdoRefRu = (mdoReferenceOwner.getMdoRefRu() + "." + mdoType.getNameRu() + "." + name).intern();
+    var mdoRef = stringInterner.intern(mdoReferenceOwner.getMdoRef() + "." + mdoType.getName() + "." + name);
+    var mdoRefRu = stringInterner.intern(mdoReferenceOwner.getMdoRefRu() + "." + mdoType.getNameRu() + "." + name);
 
     return getOrCompute(mdoType, mdoRef, mdoRefRu);
   }


### PR DESCRIPTION
## Описание
<!--- ОБЯЗАТЕЛЬНО опишите внесенные изменения -->

Перенес MdoReference из MDClasses (версия в разработке).
В классе реализована поддержка двуязычного представления ссылок, кеширование и поиск. В том числе есть возможность каскадго создания ссылок (см примеры в тестах).

## Связанные задачи
<!--- Для каждого PR обязательно наличие связанной задачи (issue). -->
<!--- Необходимо указать ключи задач, предваряя их символом #, например -->
<!---Closes #123 -->
<!--  -->
<!-- ВНИМАНИЕ: Без ссылки на задачу пулл-реквест не будет принят! -->
<!--  -->
Closes:

## Чеклист
<!--- Перед отправкой пройдите по списку и поставьте отметку для каждого выполненного действия -->
<!--- Если не понятно, что подразумевается - спросите в чате проекта https://t.me/bsl_language_server -->

### Общие

- [x] Ветка PR обновлена из develop
- [x] Отладочные, закомментированные и прочие, не имеющие смысла участки кода удалены
- [x] Изменения покрыты тестами
- [x] Обязательные действия перед коммитом выполнены (запускал команду `gradlew precommit`)

## Дополнительно
<!--- Различная дополнительная информация, скриншоты и т.д. -->
