### PR TITLE
fix: DontUse-режим совместимости доминирует над любой версией (8.5+)

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -11,7 +11,7 @@ plugins {
     id("io.freefair.javadoc-links") version "9.2.0"
     id("io.freefair.javadoc-utf-8") version "9.2.0"
 //    id("io.freefair.maven-central.validate-poms") version "9.2.0"
-    id("com.github.ben-manes.versions") version "0.53.0"
+    id("com.github.ben-manes.versions") version "0.54.0"
     id("ru.vyarus.pom") version "3.0.0"
     id("org.jreleaser") version "1.23.0"
     id("org.sonarqube") version "7.2.3.7755"

--- a/src/main/java/com/github/_1c_syntax/bsl/support/CompatibilityMode.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/support/CompatibilityMode.java
@@ -55,7 +55,10 @@ public class CompatibilityMode {
   public CompatibilityMode(String value) {
 
     if (value.equalsIgnoreCase(DONT_USE) || value.isEmpty()) {
-      setVersionComponents(THIRD_VERSION, MAX_VERSION);
+      // «Совместимость не используется» — исполнение на актуальной платформе без
+      // ограничений. Представляем как 8.99.99, чтобы режим доминировал над любой
+      // конкретной версией (включая семейство 8.5+), а не трактовался как 8.3.99.
+      setVersionComponents(MAX_VERSION, MAX_VERSION);
       return;
     }
 

--- a/src/test/java/com/github/_1c_syntax/bsl/support/CompatibilityModeTest.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/support/CompatibilityModeTest.java
@@ -43,7 +43,7 @@ class CompatibilityModeTest {
     assertThat(version.getVersion()).isEqualTo(99);
 
     version = new CompatibilityMode(versionDontUse);
-    assertThat(version.getMinor()).isEqualTo(3);
+    assertThat(version.getMinor()).isEqualTo(99);
     assertThat(version.getVersion()).isEqualTo(99);
 
     version = new CompatibilityMode(version8_3_10);
@@ -56,7 +56,7 @@ class CompatibilityModeTest {
     assertThat(version.getVersion()).isZero();
 
     version = new CompatibilityMode();
-    assertThat(version.getMinor()).isEqualTo(3);
+    assertThat(version.getMinor()).isEqualTo(99);
     assertThat(version.getVersion()).isEqualTo(99);
   }
 
@@ -74,6 +74,22 @@ class CompatibilityModeTest {
     assertThat(CompatibilityMode.compareTo(versionB, versionC)).isEqualTo(-1);
     assertThat(CompatibilityMode.compareTo(versionA, versionC)).isEqualTo(-1);
 
+  }
+
+  @Test
+  void compareToDontUseDominates() {
+    // «Режим совместимости не используется» доминирует над любой конкретной
+    // версией, включая семейство 8.5+ (ранее (3,99) проигрывало (5,x)).
+    var dontUse = new CompatibilityMode();
+    var version85 = new CompatibilityMode(5, 2);
+    var version8310 = new CompatibilityMode(3, 10);
+
+    assertThat(CompatibilityMode.compareTo(version85, dontUse)).isEqualTo(1);
+    assertThat(CompatibilityMode.compareTo(dontUse, version85)).isEqualTo(-1);
+    assertThat(CompatibilityMode.compareTo(version8310, dontUse)).isEqualTo(1);
+    assertThat(CompatibilityMode.compareTo(dontUse, new CompatibilityMode("DontUse"))).isZero();
+    // Явная (3,99) — не «DontUse», сравнивается численно и проигрывает 8.5.
+    assertThat(CompatibilityMode.compareTo(new CompatibilityMode(3, 99), version85)).isEqualTo(1);
   }
 
   @Test
@@ -95,7 +111,8 @@ class CompatibilityModeTest {
     assertThat(versionF.its82()).isFalse();
     assertThat(versionF.its83()).isFalse();
     assertThat(versionF.its85()).isFalse();
-    assertThat(versionUNK.its83()).isTrue();
+    // DontUse (8.99.99) не относится к конкретному семейству версий.
+    assertThat(versionUNK.its83()).isFalse();
   }
 
 }


### PR DESCRIPTION
## Проблема

Режим совместимости `DontUse` (или пустое значение) означает исполнение на актуальной платформе без ограничений и должен сравниваться как самая свежая версия. Прежнее представление `(3, 99)` проигрывало семейству **8.5+** (`minor 5 > 3`), из-за чего `CompatibilityMode.compareTo` давал неверный результат для потребителей, сравнивающих версию членов платформы с режимом совместимости проекта.

## Решение

`DontUse` теперь представляется как `8.99.99` (`minor = version = 99`) и численно доминирует над любой конкретной версией в `compareTo`. `its8x()` для `DontUse` становится `false` (режим не относится к конкретному семейству версий).

Тесты `CompatibilityModeTest` обновлены (новый `compareToDontUseDominates`, скорректированы `testParse`/`its8x`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)